### PR TITLE
Do not connect across Breaking Ground robotic parts

### DIFF
--- a/GameData/KerbalJointReinforcement/Plugin/PluginData/KerbalJointReinforcement/config.xml
+++ b/GameData/KerbalJointReinforcement/Plugin/PluginData/KerbalJointReinforcement/config.xml
@@ -30,6 +30,10 @@
     <string name="exemptModuleType2">KerbalEVA</string>
     <string name="exemptModuleType3">MuMechToggle</string>
     <string name="exemptModuleType4">ModuleKerbetrotterHitch</string>
+    <string name="exemptModuleType5">ModuleRoboticServoHinge</string>
+    <string name="exemptModuleType6">ModuleRoboticServoPiston</string>
+    <string name="exemptModuleType7">ModuleRoboticServoRotor</string>
+    <string name="exemptModuleType8">ModuleRoboticRotationServo</string>
 
     <string name="decouplerStiffeningExtensionType0">ModuleEngines</string>
     <string name="decouplerStiffeningExtensionType1">ModuleEnginesFX</string>


### PR DESCRIPTION
I had a lot of trouble trying to making Breaking Ground robotics to work as they just become inexplicably stuck.
Took me a while to realize that KJR is unintentionally breaking robotics by connecting parts across robotic hinges and thus making it impossible for robotic parts to move their connected parts.
Once I added these lines to exclude robotics parts, all the robotics began to work as expected.