### PR TITLE
Add option to create world-space joints for vessels in prelaunch

### DIFF
--- a/GameData/KerbalJointReinforcement/Plugin/PluginData/KerbalJointReinforcement/config.xml
+++ b/GameData/KerbalJointReinforcement/Plugin/PluginData/KerbalJointReinforcement/config.xml
@@ -3,8 +3,8 @@
     <bool name="reinforceAttachNodes">1</bool>
     <bool name="multiPartAttachNodeReinforcement">1</bool>
     <bool name="reinforceDecouplersFurther">1</bool>
-    <bool name="reinforceLaunchClampsFurther">1</bool>
-    <bool name="clampJointHasInfiniteStrength">0</bool>
+    <bool name="reinforceLaunchClampsFurther">0</bool>
+    <bool name="worldSpaceJoints">1</bool>
     <bool name="useVolumeNotArea">1</bool>
     <bool name="debug">0</bool>
 

--- a/KerbalJointReinforcement/KerbalJointReinforcement/KJRGroundJointModule.cs
+++ b/KerbalJointReinforcement/KerbalJointReinforcement/KJRGroundJointModule.cs
@@ -68,6 +68,12 @@ namespace KerbalJointReinforcement
             {
                 GameEvents.onVesselWasModified.Add(OnVesselWasModified);
                 subscribedToEvents = true;
+
+                // By the time the code gets here, the stock CheckGroundCollision() method has been run at least once.
+                // With the extra world-space joints, it's safe to make the assumption that the vessel will
+                // never shift in a significant way so any further collision checks aren't necessary.
+                // This also means that stock code will no longer shift the vessel up or down when coming off rails.
+                vessel.skipGroundPositioning = true;
             }
             else
             {

--- a/KerbalJointReinforcement/KerbalJointReinforcement/KJRGroundJointModule.cs
+++ b/KerbalJointReinforcement/KerbalJointReinforcement/KJRGroundJointModule.cs
@@ -1,0 +1,127 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace KerbalJointReinforcement
+{
+    public class KJRGroundJointModule : PartModule
+    {
+        private const int PartsToPick = 3;
+
+        private List<Part> pickedMassiveParts = new List<Part>();
+        private List<Part> clampParts;
+        private Dictionary<Part, FixedJoint> joints = new Dictionary<Part, FixedJoint>();
+        private bool alreadyUnpacked = false;
+        private bool subscribedToEvents = false;
+
+        public void Init(List<Part> clampParts)
+        {
+            this.clampParts = clampParts;
+
+            Part[] orderedParts = vessel.parts.OrderByDescending(p => p.physicsMass).ToArray();
+            int i = 0;
+            int uniquePartsPicked = 0;
+            while (uniquePartsPicked < PartsToPick && i < orderedParts.Length)
+            {
+                Part mPart = orderedParts[i];
+                i++;
+
+                if (clampParts.Contains(mPart) || pickedMassiveParts.Contains(mPart))
+                    continue;
+
+                pickedMassiveParts.Add(mPart);
+                uniquePartsPicked++;
+
+                // Add all symmetry counterparts too but they do not count towards the number of unique parts that should get selected
+                if (mPart.symmetryCounterparts.Count > 0)
+                {
+                    pickedMassiveParts.AddRange(mPart.symmetryCounterparts);
+                }
+            }
+        }
+
+        public void OnPartUnpack()
+        {
+            if (alreadyUnpacked)
+                return;
+
+            alreadyUnpacked = true;
+
+            foreach (Part part in pickedMassiveParts)
+            {
+                if (part == null) continue;
+
+                FixedJoint newJoint = part.gameObject.AddComponent<FixedJoint>();
+                joints.Add(part, newJoint);
+
+                newJoint.connectedBody = null;
+                newJoint.anchor = Vector3.zero;
+                newJoint.axis = Vector3.up;
+                newJoint.breakForce = Mathf.Infinity;
+                newJoint.breakTorque = Mathf.Infinity;
+
+                if (KJRJointUtils.settings.debug)
+                    Debug.Log($"[KJR] {part.partInfo.title} connected to ground");
+            }
+
+            if (joints.Count > 0)
+            {
+                GameEvents.onVesselWasModified.Add(OnVesselWasModified);
+                subscribedToEvents = true;
+            }
+            else
+            {
+                part.RemoveModule(this);
+            }
+        }
+
+        private void OnVesselWasModified(Vessel v)
+        {
+            BreakAllInvalidJoints();
+        }
+
+        private void BreakAllInvalidJoints()
+        {
+            foreach (Part key in joints.Keys.ToArray())
+            {
+                if (key == null || !clampParts.Find(cp => cp != null && cp.vessel == key.vessel))
+                {
+                    // All clamps gone, remove the joint
+                    Destroy(joints[key]);
+                    joints.Remove(key);
+                }
+            }
+
+            if (joints.Count == 0)
+                part.RemoveModule(this);
+        }
+
+        public void OnPartPack()
+        {
+            if (subscribedToEvents)
+            {
+                GameEvents.onVesselWasModified.Remove(OnVesselWasModified);
+                subscribedToEvents = false;
+            }
+
+            foreach (FixedJoint j in joints.Values)
+                Destroy(j);
+
+            joints.Clear();
+            alreadyUnpacked = false;
+        }
+
+        public void OnDestroy()
+        {
+            if (subscribedToEvents)
+            {
+                GameEvents.onVesselWasModified.Remove(OnVesselWasModified);
+            }
+
+            foreach (FixedJoint j in joints.Values)
+                Destroy(j);
+
+            joints.Clear();
+        }
+    }
+}

--- a/KerbalJointReinforcement/KerbalJointReinforcement/KJRJointUtils.cs
+++ b/KerbalJointReinforcement/KerbalJointReinforcement/KJRJointUtils.cs
@@ -152,7 +152,6 @@ namespace KerbalJointReinforcement
         public static void AddLaunchClampReinforcementModule(Part p)
         {
             var pm = (KJRLaunchClampReinforcementModule)p.AddModule(nameof(KJRLaunchClampReinforcementModule));
-            pm.clampJointHasInfiniteStrength = settings.clampJointHasInfiniteStrength;
             pm.OnPartUnpack();
             if (settings.debug)
                 Debug.Log("[KJR] Added KJRLaunchClampReinforcementModule to part " + p.partInfo.title);
@@ -176,7 +175,7 @@ namespace KerbalJointReinforcement
                 debugString.AppendLine("Reinforce Attach Nodes: " + settings.reinforceAttachNodes);
                 debugString.AppendLine("Reinforce Decouplers Further: " + settings.reinforceDecouplersFurther);
                 debugString.AppendLine("Reinforce Launch Clamps Further: " + settings.reinforceLaunchClampsFurther);
-                debugString.AppendLine("Clamp Joint Has Infinite Strength: " + settings.clampJointHasInfiniteStrength);
+                debugString.AppendLine("World Space Joints: " + settings.worldSpaceJoints);
                 debugString.AppendLine("Use Volume For Calculations, Not Area: " + settings.useVolumeNotArea);
 
                 debugString.AppendLine("\n\rMass For Joint Adjustment: " + settings.massForAdjustment);

--- a/KerbalJointReinforcement/KerbalJointReinforcement/KJRSettings.cs
+++ b/KerbalJointReinforcement/KerbalJointReinforcement/KJRSettings.cs
@@ -30,11 +30,11 @@ namespace KerbalJointReinforcement
         public bool reinforceDecouplersFurther = true;
 
         [GameParameters.CustomParameterUI("Toggle stiffening of launch clamp connections", autoPersistance = false)]
-        public bool reinforceLaunchClampsFurther = true;
+        public bool reinforceLaunchClampsFurther = false;
 
-        [GameParameters.CustomParameterUI("Toggle clamp connections that are completely rigid", autoPersistance = false,
-            toolTip = "With this option enabled, even the heaviest of rockets shouldn't move a millimeter when loaded onto the launch pad")]
-        public bool clampJointHasInfiniteStrength = false;
+        [GameParameters.CustomParameterUI("Attach vessel to ground", autoPersistance = false,
+            toolTip = "Connects the heaviest parts of the vessel directly to ground if it is waiting to be launched and has launch clamps")]
+        public bool worldSpaceJoints = true;
 
         [GameParameters.CustomParameterUI("Calculate by area", autoPersistance = false,
             toolTip = "Switches to calculating connection area based on volume, not area; not technically correct, but allows a better approximation of very large rockets")]
@@ -81,8 +81,8 @@ namespace KerbalJointReinforcement
             reinforceAttachNodes = config.GetValue(nameof(reinforceAttachNodes), true);
             multiPartAttachNodeReinforcement = config.GetValue(nameof(multiPartAttachNodeReinforcement), true);
             reinforceDecouplersFurther = config.GetValue(nameof(reinforceDecouplersFurther), true);
-            reinforceLaunchClampsFurther = config.GetValue(nameof(reinforceLaunchClampsFurther), true);
-            clampJointHasInfiniteStrength = config.GetValue(nameof(clampJointHasInfiniteStrength), false);
+            reinforceLaunchClampsFurther = config.GetValue(nameof(reinforceLaunchClampsFurther), false);
+            worldSpaceJoints = config.GetValue(nameof(worldSpaceJoints), true);
             useVolumeNotArea = config.GetValue(nameof(useVolumeNotArea), true);
             debug = config.GetValue(nameof(debug), false);
 
@@ -139,7 +139,7 @@ namespace KerbalJointReinforcement
                     isDirty |= UpdateConfigValue(config, "multiPartAttachNodeReinforcement", multiPartAttachNodeReinforcement);
                     isDirty |= UpdateConfigValue(config, "reinforceDecouplersFurther", reinforceDecouplersFurther);
                     isDirty |= UpdateConfigValue(config, "reinforceLaunchClampsFurther", reinforceLaunchClampsFurther);
-                    isDirty |= UpdateConfigValue(config, "clampJointHasInfiniteStrength", clampJointHasInfiniteStrength);
+                    isDirty |= UpdateConfigValue(config, "worldSpaceJoints", worldSpaceJoints);
                     isDirty |= UpdateConfigValue(config, "useVolumeNotArea", useVolumeNotArea);
                     isDirty |= UpdateConfigValue(config, "debug", debug);
 

--- a/KerbalJointReinforcement/KerbalJointReinforcement/KerbalJointReinforcement.csproj
+++ b/KerbalJointReinforcement/KerbalJointReinforcement/KerbalJointReinforcement.csproj
@@ -56,6 +56,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="KJRGroundJointModule.cs" />
     <Compile Include="KJRManager.cs" />
     <Compile Include="KJRJointUtils.cs" />
     <Compile Include="KJRLaunchClampReinforcementModule.cs" />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Kerbal Joint Reinforcement, v3.7.5
+Kerbal Joint Reinforcement, v3.8.0
 ==========================
 
 Physics stabilizer plugin for Kerbal Space Program
@@ -61,7 +61,7 @@ General Values
 	bool	multiPartAttachNodeReinforcement	1			--Toggles additional stiffening by connecting parts in a stack one part further, but at a weaker strength
 	bool	reinforceDecouplersFurther		1			--Toggles stiffening of interstage connections
 	bool	reinforceLaunchClampsFurther		1			--Toggles stiffening of launch clamp connections
-	bool	clampJointHasInfiniteStrength		0			--Toggles clamp joints that are completely rigid
+	bool	worldSpaceJoints			1			--Connects the heaviest parts of the vessel directly to ground if it is waiting to be launched and has launch clamps
 	bool	useVolumeNotArea			1			--Switches to calculating connection area based on volume, not area; not technically correct, but allows a better approximation of very large rockets
 	bool	debug					0			--Toggles debug output to log; please activate and provide log if making a bug report
 	float	massForAdjustment			0.01			--Parts below this mass will not be stiffened
@@ -112,6 +112,10 @@ Decoupler Stiffening Extension Types
 ***********************
 ****** CHANGELOG ******
 ***********************
+v3.8.0
+
+	--Add option to connect the heaviest parts of the vessel directly to ground. Replaces the lampJointHasInfiniteStrength option.
+
 v3.7.5
 
 	--Fix another case of inter-vessel joints getting created on decoupling


### PR DESCRIPTION
Picks 3 parts (or more if in symmetry) on the vessel and creates world-space joints for them. Appears to be really effective in stabilizing vessels coming off rails.
Replaces the hacky infinite strength clamp option entirely.